### PR TITLE
AnnotationBear: Allow missing language setting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Use >= for development versions so that source builds always work
-coala>=0.9
+coala>=0.9.dev20161207132350
 munkres3~=1.0
 pylint~=1.6
 autopep8~=1.2

--- a/tests/general/KeywordBearTest.py
+++ b/tests/general/KeywordBearTest.py
@@ -43,6 +43,17 @@ class KeywordBearDiffTest(unittest.TestCase):
                           dependency_results=self.dep_results) as result:
             self.assertEqual(result, [])
 
+    def test_no_language(self):
+        text = ['# todo 123']
+        section = Section('')
+        section.append(Setting('keywords', 'TODO'))
+
+        with execute_bear(KeywordBear(section, Queue()), 'F', text,
+                          dependency_results=self.dep_results) as result:
+            self.assertEqual(result[0].diffs, {})
+            self.assertEqual(result[0].affected_code[0].start.line, 1)
+            self.assertEqual(len(result), 1)
+
     def test_keyword_in_comment(self):
         dep_results = {
             'AnnotationBear': {}


### PR DESCRIPTION
A missing language setting is not any different from
a language name which has a Language definition that
does not contain the necessary information to correctly
parse the file.

Use a special 'UnknownLanguage' in this scenario.

Also upgrades AnnotationBear from LanguageDefinition
to the new Language.

Fixes https://github.com/coala/coala-bears/issues/1012
Closes https://github.com/coala/coala-bears/issues/1095